### PR TITLE
Reverse slices to orient patient head at slice 0

### DIFF
--- a/dicom_numpy/combine_slices.py
+++ b/dicom_numpy/combine_slices.py
@@ -238,4 +238,4 @@ def _slice_spacing(slice_datasets):
 
 def _sort_by_slice_spacing(slice_datasets):
     slice_spacing = _slice_positions(slice_datasets)
-    return [d for (s, d) in sorted(zip(slice_spacing, slice_datasets))]
+    return [d for (s, d) in sorted(zip(slice_spacing, slice_datasets), reverse=True)]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,12 @@ Version 1.5
 - Added the `rescale` option to `combine_slices`
 - Made `combine_slices`'s returned ndarray use column-major ordering
 
+Version 2.0
+-----------
+
+- Changed the behavior of `combine_slices` to stack slices from head (slice 0)
+  to foot (slice -1). Note that this is the reverse of the behavior in v1.*.
+
 
 Contributing
 ============

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='dicom_numpy',
-    version='0.1.6',
+    version='0.2.0',
     description='Extract image data into a 3D numpy array from a set of DICOM files.',
     long_description=long_description,
     url='https://github.com/innolitics/dicom-numpy',

--- a/tests/test_combine_slices.py
+++ b/tests/test_combine_slices.py
@@ -15,7 +15,7 @@ class TestCombineSlices:
     def test_simple_axial_set(self, axial_slices):
         combined, _ = combine_slices(axial_slices[0:2])
 
-        manually_combined = np.dstack((axial_slices[0].pixel_array.T, axial_slices[1].pixel_array.T))
+        manually_combined = np.dstack((axial_slices[1].pixel_array.T, axial_slices[0].pixel_array.T))
         assert np.array_equal(combined, manually_combined)
 
 


### PR DESCRIPTION
The top of the patient is considered the first slice in a volume, while
the bottom of the patient is considered the last. In order to reflect
this in the slice ordering, sorting by ImagePatientPosition must be
reversed (starting from the highest point in the slice direction and
ending at the lowest).

Please note that this would be a major breaking change for current users of the library.